### PR TITLE
Update default frontend API URL to chatter.pw

### DIFF
--- a/blog-frontend/src/config/api.js
+++ b/blog-frontend/src/config/api.js
@@ -1,3 +1,3 @@
-const API_BASE_URL = process.env.REACT_APP_API_URL || "http://localhost:8080";
+const API_BASE_URL = process.env.REACT_APP_API_URL || "http://chatter.pw:8080";
 
 export default API_BASE_URL;


### PR DESCRIPTION
### Motivation
- Route frontend API calls to the actual backend host by default so requests use `http://chatter.pw:8080` when `REACT_APP_API_URL` is not set.

### Description
- Change the default API base URL in `blog-frontend/src/config/api.js` from `"http://localhost:8080"` to `"http://chatter.pw:8080"`.

### Testing
- Built the frontend with `cd blog-frontend && npm run build`, ran backend tests with `cd blog-backend && go test ./...`, and built the backend with `cd blog-backend && go build ./...`; all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c60879f6c083309a0a9276d2c9befc)